### PR TITLE
Ignore linguist for vendors and generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/lib/** linguist-detectable=false
+/node_modules/** linguist-detectable=false


### PR DESCRIPTION
As `/lib` and `/node_modules` are generated code / vendors, we should ignore linguist detection through [.gitattributes](https://github.com/github/linguist#using-gitattributes) file. See [ghaction-xgo](https://github.com/crazy-max/ghaction-xgo) as an example.