### PR TITLE
Fix example tests

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -4,7 +4,8 @@ import * as cp from 'child_process'
 import * as path from 'path'
 
 test('throws invalid number', async() => {
-    await expect(wait('foo')).rejects.toThrow('milleseconds not a number');
+    const input = parseInt('foo', 10);
+    await expect(wait(input)).rejects.toThrow('milleseconds not a number');
 });
 
 test('wait 500 ms', async() => {
@@ -19,5 +20,8 @@ test('wait 500 ms', async() => {
 test('test runs', () => {
     process.env['INPUT_MILLISECONDS'] = '500';
     const ip = path.join(__dirname, '..', 'lib', 'main.js');
-    console.log(cp.execSync(`node ${ip}`).toString());
-})
+    const options: cp.ExecSyncOptions = {
+        env: process.env
+    };
+    console.log(cp.execSync(`node ${ip}`, options).toString());
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ async function run() {
     console.log(`Waiting ${ms} milliseconds ...`)
 
     core.debug((new Date()).toTimeString())
-    await wait(parseInt(ms));
+    await wait(parseInt(ms, 10));
     core.debug((new Date()).toTimeString())
 
     core.setOutput('time', new Date().toTimeString());

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -1,7 +1,7 @@
-export function wait(milliseconds) {
-    return new Promise((resolve, reject) => {
-        if (typeof(milliseconds) !== 'number') { 
-        throw new Error('milleseconds not a number'); 
+export function wait(milliseconds: number) {
+    return new Promise((resolve) => {
+        if (isNaN(milliseconds)) { 
+            throw new Error('milleseconds not a number'); 
         }
 
         setTimeout(() => resolve("done!"), milliseconds)


### PR DESCRIPTION
The third example test was not having it's input set correctly, and was only waiting for `NaN` seconds. 

See [output from test](https://github.com/actions/typescript-action/commit/8984af0b7ead4ffd76c1ced0e0ed92520b21bf00/checks?check_suite_id=238998774#step:5:12):
```
  console.log __tests__/main.test.ts:22
    Waiting  milliseconds ...
    ##[set-output name=time;]19:24:01 GMT+0000 (Coordinated Universal Time)
```

`ParseInt` will alreays return a `number` (`integer` or `NaN`), so checking the type of the input was not valid.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt

I'm not sure why setting the `process.env` before calling `cp.execSync` doesn't work as expected, as the docs say the default `env` should be `process.env`: https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options