### PR TITLE
Make action.yml consistent with starter code

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Your name here'
 description: 'Provide a description here'
 author: 'Your name or organization here'
 inputs:
-  myInput:              # change this
+  milliseconds:           # change this
     description: 'input description here'
     default: 'default value if applicable'
 runs:


### PR DESCRIPTION
Starter code reads `milliseconds` input, not `myInput`.