### PR TITLE
Bumping actions/core version to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "node12-template-action",
+  "name": "typescript-action",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.0.0.tgz",
-      "integrity": "sha512-aMIlkx96XH4E/2YZtEOeyrYQfhlas9jIRkfGPqMwXD095Rdkzo4lB6ZmbxPQSzD+e1M+Xsm98ZhuSMYGv/AlqA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-ZKdyhlSlyz38S6YFfPnyNgCDZuAF2T0Qv5eHflNWytPS8Qjvz39bZFMry9Bb/dpSnqWcNeav5yM2CTYpJeY+Dw=="
     },
     "@babel/code-frame": {
       "version": "7.5.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "YourNameOrOrganization",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.0.0"
+    "@actions/core": "^1.2.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",


### PR DESCRIPTION
Was building an Action and noticed that `setSecret` wasn't available in core. Bumping the version so we have latest.