### PR TITLE
Prettier 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4991,9 +4991,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jest": "^24.9.0",
     "jest-circus": "^24.9.0",
     "js-yaml": "^3.13.1",
-    "prettier": "^1.19.1",
+    "prettier": "2.0.4",
     "ts-jest": "^24.2.0",
     "typescript": "^3.6.4"
   }


### PR DESCRIPTION
This upgrades us to the latest version of [Prettier](https://prettier.io/). See [the blog post introducing version 2.0](https://prettier.io/blog/2020/03/21/2.0.0.html).

I also switched to pinning an exact version of Prettier, [as suggested in the install docs](https://prettier.io/docs/en/install.html).