### PR TITLE
docs: remove unnessary `]` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See the [versioning documentation](https://github.com/actions/toolkit/blob/maste
 
 ## Validate
 
-You can now validate the action by referencing `./` in a workflow in your repo (see [test.yml](.github/workflows/test.yml)])
+You can now validate the action by referencing `./` in a workflow in your repo (see [test.yml](.github/workflows/test.yml))
 
 ```yaml
 uses: ./


### PR DESCRIPTION
FIx a typo