### PR TITLE
Removed the node_module line and it's associated comment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Dependency directory
-node_modules
-
 # Rest pulled from https://github.com/github/gitignore/blob/master/Node.gitignore
 # Logs
 logs


### PR DESCRIPTION
The [official documentation](https://help.github.com/en/actions/creating-actions/creating-a-javascript-action#commit-tag-and-push-your-action-to-github) from github tells users to commit the node_modules directory. Please have a look, I could be wrong