### PR TITLE
Update readme for ncc

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ $ git commit -a -m "prod dependencies"
 $ git push origin releases/v1
 ```
 
+Note: We recommend using the `--license` option for ncc, which will create a license file for all of the production node modules used in your project.
+
 Your action is now published! :rocket: 
 
 See the [versioning documentation](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md)


### PR DESCRIPTION
We should suggest to users that they use the `--license` flag in ncc to provide attribution to the third party node modules they may be using.