### PR TITLE
Avoid spawning a shell when running node in test

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -19,9 +19,10 @@ test('wait 500 ms', async () => {
 // shows how the runner will run a javascript action with env / stdout protocol
 test('test runs', () => {
   process.env['INPUT_MILLISECONDS'] = '500'
+  const np = process.execPath
   const ip = path.join(__dirname, '..', 'lib', 'main.js')
-  const options: cp.ExecSyncOptions = {
+  const options: cp.ExecFileSyncOptions = {
     env: process.env
   }
-  console.log(cp.execSync(`node ${ip}`, options).toString())
+  console.log(cp.execFileSync(np, [ip], options).toString())
 })


### PR DESCRIPTION
Hi!

`execSync` by default spawns a shell to exec the specified command.
And, without specifying an absolute path to the node binary, it will be searched in `PATH` where yarn prepends a temporary directory containing a shell script called **node** that [wraps the original node binary with exec](https://github.com/yarnpkg/yarn/blob/a4708b29ac74df97bac45365cba4f1d62537ceb7/src/util/portable-script.js#L48), resulting in implicitly chaining a shell again.

On some Linux distros, the default non-interactive shell, such as the Dash shell of Debian, silently discards dashes (`-`) in names of environment variables. But GitHub Actions does allow dashes in names of input variables which are then converted to environment variables in the form of `INPUT_<VARIABLE_NAME>`.

Therefore, the test code in _main.test.ts_ is somewhat error-prone if someone like me tries to adapt it for an action whose input variables have a dash in names. I spent my Saturday to learn this experience, by playing with Nodejs and gdb, frustrated. Hence I suppose it is worth submitting a PR.

The PR solves the problem by using execFileSync, which by default exec directly without spawning a shell, to run node with its
absolute path.