### PR TITLE
Revert "Bump typescript from 3.9.7 to 4.0.2 (#109)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8812,9 +8812,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "js-yaml": "^3.14.0",
     "prettier": "2.1.1",
     "ts-jest": "^24.3.0",
-    "typescript": "^4.0.2"
+    "typescript": "^3.9.7"
   }
 }


### PR DESCRIPTION
This reverts commit edb1bf6da7f5571c7f86e649aad0c6fdba551fac.