### PR TITLE
Add .editorconfig matching prettier and eslint config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Largely supported in modern IDE to override local default setting with .editorconfig to match prettier and eslint settings for better code authoring quality of life in IDE or TextEditor. (remove pesky wavy red lines when auto format)