### PR TITLE
Resolve error with eslint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist/
 lib/
 node_modules/
+jest.config.js


### PR DESCRIPTION
Fixes

```text
Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser. 
The file does not match your project config: jest.config.js. 
The file must be included in at least one of the projects provided.
```

@damccorm @hross 