### PR TITLE
Format files in subdirectories on Linux env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc",
-    "format": "prettier --write **/*.ts",
-    "format-check": "prettier --check **/*.ts",
+    "format": "prettier --write '**/*.ts'",
+    "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts",
     "package": "ncc build --source-map --license licenses.txt",
     "test": "jest",


### PR DESCRIPTION
We need quotes to format files in sub directories on Linux env.

https://prettier.io/docs/en/cli.html
> Don’t forget the quotes around the globs! The quotes make sure that Prettier CLI expands the globs rather than your shell, which is important for cross-platform usage.


----------
P.S. 
Thank you for nice template :bow:
It's easy to understand how to make github-actions and easy to use :+1:
