### PR TITLE
Keep dist dir updated when Dependabot updates a dependency

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-ncc:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -1,0 +1,35 @@
+# When Dependabot updates dependency, this workflow synchronize the change
+# to the /dist dir to let users enjoy new feature without manual sync.
+name: Update the dist dir
+on:
+  pull_request_target:
+    types:
+      - labeled # for initial execution
+      - synchronize # to support `@dependabot recreate` command
+jobs:
+  run-ncc:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ github.token }} # Replace github.token with PAT (personal access token) if you need to trigger a new workflow. https://git.io/JcHD9
+      - name: Use Node.js v12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          # It is not suggested to cache for the pull_request_target event
+          # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
+      - name: Update the dist directory
+        run: |
+          npm ci
+          npm run build
+          npm run package
+          if [[ $(git status -s -- dist | wc -l) -gt 0 ]]; then
+            git add dist
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git commit -m "chore: sync the dependency update to the /dist dir"
+            git push origin HEAD
+          fi


### PR DESCRIPTION
Hi folks 👋 
Thanks for providing a great template for typescript action, I've made several actions based on this.

Currently, this template uses Dependabot but it won't run `npm run package` so we **need to add a commit to the PR manually** or the `dist` file will keep using an old dependency. I feel it's a kind of toil, and want to suggest automation based on GitHub Action.

(I personally use [semantic-release to keep the dir updated](https://dev.to/kengotoda/a-complete-guide-to-use-dependabot-with-semantic-release-and-vercel-ncc-for-github-actions-230p), but it's a too big change for this template I thought.)

This action will run `npm ci` and `npm run package` in PR labeled with `dependencies`, and push a commit if there is an update in the `dist` dir. To push changes, this workflow uses `pull_request_target` event that makes `GITHUB_TOKEN` able to make a change.

Note that the [commit pushed by `GITHUB_TOKEN` will not trigger a new workflow](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow), so if template user wants a new workflow run, they need to use PAT instead.

That's all of my suggestions, please tell me your considerations.
Thanks for reading my PR, let's make Actions development productive and fun together! 😃