### PR TITLE
Fix check-dist workflow not actually rebuilding

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -32,7 +32,9 @@ jobs:
         run: npm ci
 
       - name: Rebuild the dist/ directory
-        run: npm run build
+        run: |
+          npm run build
+          npm run package
 
       - name: Compare the expected and actual dist/ directories
         run: |


### PR DESCRIPTION
The workflow was missing the `npm run package` step. Without this the check will always succeed as the /dist folder won't be updated.