### PR TITLE
add instructions to test inputs on action

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -19,6 +19,7 @@ test('wait 500 ms', async () => {
 
 // shows how the runner will run a javascript action with env / stdout protocol
 test('test runs', () => {
+  // Set all expected inputs (even defaults) with prefix INPUT_ and capitalized input name
   process.env['INPUT_MILLISECONDS'] = '500'
   const np = process.execPath
   const ip = path.join(__dirname, '..', 'lib', 'main.js')


### PR DESCRIPTION
it wasn't immediately obvious that these inputs had to be set according to an expected syntax, this added comment should clear things up