### PR TITLE
Enable ESLint for tests too

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
     "parserOptions": {
       "ecmaVersion": 9,
       "sourceType": "module",
-      "project": "./tsconfig.json"
+      "project": "./tsconfig.eslintrc.json"
     },
     "rules": {
       "i18n-text/no-en": "off",

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,8 +1,9 @@
-import {wait} from '../src/wait'
-import * as process from 'process'
 import * as cp from 'child_process'
 import * as path from 'path'
+import * as process from 'process'
+
 import {expect, test} from '@jest/globals'
+import {wait} from '../src/wait'
 
 test('throws invalid number', async () => {
   const input = parseInt('foo', 10)
@@ -13,17 +14,18 @@ test('wait 500 ms', async () => {
   const start = new Date()
   await wait(500)
   const end = new Date()
-  var delta = Math.abs(end.getTime() - start.getTime())
+  const delta = Math.abs(end.getTime() - start.getTime())
   expect(delta).toBeGreaterThan(450)
 })
 
 // shows how the runner will run a javascript action with env / stdout protocol
-test('test runs', () => {
-  process.env['INPUT_MILLISECONDS'] = '500'
+test('runs', () => {
+  process.env.INPUT_MILLISECONDS = '500'
   const np = process.execPath
   const ip = path.join(__dirname, '..', 'lib', 'main.js')
   const options: cp.ExecFileSyncOptions = {
     env: process.env
   }
-  console.log(cp.execFileSync(np, [ip], options).toString())
+  const output = cp.execFileSync(np, [ip], options).toString()
+  expect(output).toMatch(/::debug::Waiting 500 milliseconds .../i)
 })

--- a/tsconfig.eslintrc.json
+++ b/tsconfig.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest"]
+  },
+  "include": [
+    "src", "__tests__"
+  ],
+  "exclude": ["node_modules"]  
+}


### PR DESCRIPTION
The template does not use ESLint for the tests.

I could enable it although I have not been able to fix one error described [here](https://github.com/actions/typescript-action/issues/473).

On the other hand, in the `package.json`:

```
  "scripts": {
    "build": "tsc",
    "format": "prettier --write '**/*.ts'",
    "format-check": "prettier --check '**/*.ts'",
    "lint": "eslint src/**/*.ts",
    "package": "ncc build --source-map --license licenses.txt",
    "test": "jest",
    "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
  },
```

I see that you `--write` fixes with `prettier` but not for `eslint` with `--fix` option. Is there a reason for that?