### PR TITLE
Set default line endings to LF avoid issues with check-dist workflow

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true,                           /* Enable all strict type-checking options. */
     "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "newLine": "lf"                           /* Use Linux line endings for outputted files to avoid issues with developing on Windows and running the check-dist workflow on ubuntu-latest */
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
I noticed that when running `npm run build` and `npm run package` on Windows the check-dist workflow failed due to line ending differences.

This PR defaults line endings to LF to avoid this problem.