### PR TITLE
Fix the "main" in package.json to point to a file that actually exists.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "TypeScript template action",
-  "main": "lib/main.js",
+  "main": "dist/main.js",
   "scripts": {
     "build": "tsc",
     "format": "prettier --write '**/*.ts'",


### PR DESCRIPTION
This is a pretty minor fix.  The `main` in package.json was pointing to "lib/main.js", but this file doesn't exist and will never exist.

In a sense, it doesn't actually matter what the `main` is set to, since GitHub will get the file to run from [action.yml](https://github.com/actions/typescript-action/blob/88a7452ac5a8c942a9b7c65df36070c952c4adc0/action.yml#L11), and this will never be published anyways... But, it might as well point to something valid.  :)