### PR TITLE
Updated README with notes about variables names

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ See the [actions tab](https://github.com/actions/typescript-action/actions) for 
 
 ## Testing
 
-To correct receive the variables values when using [`core.getInput('milliseconds')`](https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/src/main.ts#L6) on tests you need to add `INPUT_` as preffix on the name and use UPPERCASE string with `process.env`, [like this](https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/__tests__/main.test.ts#L22).
+To correct receive the variables values when using [`core.getInput('milliseconds')`](https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/src/main.ts#L6) on tests you need to add `INPUT_` as prefix on the name and use UPPERCASE string with `process.env`, [like this](https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/__tests__/main.test.ts#L22).
 
 ## Usage:
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ run()
 
 See the [toolkit documentation](https://github.com/actions/toolkit/blob/master/README.md#packages) for the various packages.
 
+## Testing
+
+To correct receive the variables values when using [`core.getInput('milliseconds')`](https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/src/main.ts#L6) on tests you need to add `INPUT_` as prefix on the name and use UPPERCASE string with `process.env`, [like this](https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/__tests__/main.test.ts#L22).
+
 ## Publish to a distribution branch
 
 Actions are run from GitHub repos so we will checkin the packed dist folder. 
@@ -99,10 +103,6 @@ with:
 ```
 
 See the [actions tab](https://github.com/actions/typescript-action/actions) for runs of this action! :rocket:
-
-## Testing
-
-To correct receive the variables values when using [`core.getInput('milliseconds')`](https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/src/main.ts#L6) on tests you need to add `INPUT_` as prefix on the name and use UPPERCASE string with `process.env`, [like this](https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/__tests__/main.test.ts#L22).
 
 ## Usage:
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ with:
 
 See the [actions tab](https://github.com/actions/typescript-action/actions) for runs of this action! :rocket:
 
+## Testing
+
+To correct receive the variables values when using [`core.getInput('milliseconds')`](https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/src/main.ts#L6) on tests you need to add `INPUT_` as preffix on the name and use UPPERCASE string with `process.env`, [like this](https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/__tests__/main.test.ts#L22).
+
 ## Usage:
 
 After testing you can [create a v1 tag](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md) to reference the stable and latest V1 action


### PR DESCRIPTION
There's nothing on the README mentioning how to test `core.getInput(...)` and why a different variable name is passed on test file.

https://github.com/actions/typescript-action/blob/569d7856399fccb879d5c13a5407ca2ae89ce047/__tests__/main.test.ts#L22

### Suggestion

- Updated README with information about variables names on tests when using core.getInput(...), need to pass `INPUT_` prefix and use uppercase string.