### PR TITLE
refactor: update eslint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^16.10.5",
     "@typescript-eslint/parser": "^5.8.1",
     "@vercel/ncc": "^0.31.1",
-    "eslint": "^7.32.0",
+    "eslint": "^8.0.1",
     "eslint-plugin-github": "^4.3.2",
     "eslint-plugin-jest": "^25.3.2",
     "jest": "^27.2.5",


### PR DESCRIPTION
Updates Eslint dependency to get rid of the peer dependency warning in the stable node release. Not sure what your support triangle is, so feel free to close it if you think this will cause too many problems.