### PR TITLE
Fix jest globals error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,8 @@ Thumbs.db
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*
+
+# IDE files
+.idea
+.vscode
+*.code-workspace

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -2,7 +2,6 @@ import {wait} from '../src/wait'
 import * as process from 'process'
 import * as cp from 'child_process'
 import * as path from 'path'
-import {expect, test} from '@jest/globals'
 
 test('throws invalid number', async () => {
   const input = parseInt('foo', 10)

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "@actions/core": "^1.6.0"
   },
   "devDependencies": {
+    "@types/jest": "^27.0.0",
     "@types/node": "^16.10.5",
     "@typescript-eslint/parser": "^5.8.1",
     "@vercel/ncc": "^0.31.1",
-    "eslint": "^7.32.0",
+    "eslint": "^8.0.1",
     "eslint-plugin-github": "^4.3.2",
     "eslint-plugin-jest": "^25.3.2",
     "jest": "^27.2.5",


### PR DESCRIPTION
This PR fixes a `@jest/globals` types error when working with this template in Vscode. It contains the following changes:
- The `@jest/globals` import was removed.
- Eslint was updated.
- Vscode files were added to the `.gitignore` file.