### PR TITLE
refactor: remove sourceMaps from production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts",
-    "package": "ncc build --source-map --license licenses.txt",
+    "package": "ncc build --license licenses.txt",
     "test": "jest",
     "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
   },


### PR DESCRIPTION
I don't think we should include source maps in the production build. It bloads the project and sometimes causes problems with the `check-dist` action (see https://github.com/vercel/ncc/issues/831).