### PR TITLE
fix workflow - check dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "description": "TypeScript template action",
   "main": "lib/main.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --newLine lf",
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts",
-    "package": "ncc build --source-map --license licenses.txt",
+    "package": "ncc build --source-map --no-cache --license licenses.txt",
     "test": "jest",
     "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
   },


### PR DESCRIPTION
**why this pull request?** 

currently the check dist/ workflow could fail if changes made on windows and action run on linux when checking diff on **index.js.map**, this is due to : 
- the tsc build could produce **CRLF** on windows and workflow run on linux is expectin **LF** as new line.
- the package could be using cached option so the file is much smaller compare to the workflow artifect.

Changes have been made to add `newLine` option on **tsc build** and add `no-cache` option on **package**