### PR TITLE
use git diff --cached or git add -N in diff check step

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -38,9 +38,10 @@ jobs:
 
       - name: Compare the expected and actual dist/ directories
         run: |
-          if [ "$(git diff --cached --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+          git add -N .
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after build.  See status below:"
-            git diff --cached --ignore-space-at-eol dist/
+            git diff --ignore-space-at-eol dist/
             exit 1
           fi
         id: diff

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -38,9 +38,9 @@ jobs:
 
       - name: Compare the expected and actual dist/ directories
         run: |
-          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+          if [ "$(git diff --cached --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after build.  See status below:"
-            git diff
+            git diff --cached --ignore-space-at-eol dist/
             exit 1
           fi
         id: diff

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Compare the expected and actual dist/ directories
         run: |
-          git add -N .
+          git add -N dist/
           if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after build.  See status below:"
             git diff --ignore-space-at-eol dist/


### PR DESCRIPTION
This is to catch very specific cases where entire files are missing from the expected build output, but there are no other differences.