### PR TITLE
Add action typings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,16 @@ jobs:
       - name: Print Output
         id: output
         run: echo "${{ steps.test-action.outputs.time }}"
+
+  validate-typings:
+    name: Validate action typings
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v3
+
+      - name: Validate
+        id: validate
+        uses: typesafegithub/github-actions-typing@v1

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,7 @@
+inputs:
+  milliseconds:
+    type: integer
+
+outputs:
+  time:
+    type: string


### PR DESCRIPTION
Closes #591.

This change introduces typings for the action's API using https://github.com/typesafegithub/github-actions-typing, along with a workflow that cross-validates them with action.yml. It helps both humans and machines reason about the API of the action in a standardized, readable way. You can also think of it as an additional linter or documentation tool.

Adoption notes:
* this mechanism is already fully functional, and is used by approx. 30 actions: https://github.com/typesafegithub/github-actions-typing/network/dependents
* it currently uses Kotlin and its JVM target, and building the docker image every time the action is run is surplus. If we decide to introduce the typings here in this template, I'm open to changing the approach to make it less resource-intensive, e.g. by prebuilding the Docker image, using JS runtime, or yet another way

# Testing done

Checked in my fork that the new workflow succeeds, see https://github.com/krzema12/typescript-action/actions/runs/6022936242/job/16338691428

<img width="149" alt="Screenshot 2023-08-30 at 11 16 42" src="https://github.com/actions/typescript-action/assets/3110813/be795cc5-b296-4334-9da0-e64d8748d2bb">