### PR TITLE
Fix ordering of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
   "devDependencies": {
     "@types/jest": "^29.5.4",
     "@types/node": "^20.5.7",
-    "@typescript-eslint/parser": "^6.5.0",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
+    "@typescript-eslint/parser": "^6.5.0",
     "@vercel/ncc": "^0.36.1",
     "eslint": "^8.48.0",
     "eslint-plugin-github": "^4.10.0",


### PR DESCRIPTION
Adding new packages via `npm` will snap these back to being alpha sorted.