### PR TITLE
Add integration tests example, fix add compiled files to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+lib/
 dist/
 node_modules/
 coverage/


### PR DESCRIPTION
I would like to suggest adding **integrations** test example to be able to debug and validate the action **locally** with short feedback loop to avoid permanent pushing to test repos, creating additional load on Github runners and debugging with console.logs.

The PR also conatins `.eslintignore` fix

`package-lock.json` changes were produced by a simple `npm install`