### PR TITLE
Update main.test.ts to actually mock the GitHub Actions core library

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -9,6 +9,9 @@
 import * as core from '@actions/core'
 import * as main from '../src/main'
 
+// Setup Jest to mock GitHub Actions core library
+jest.mock('@actions/core')
+
 // Mock the GitHub Actions core library
 const debugMock = jest.spyOn(core, 'debug')
 const getInputMock = jest.spyOn(core, 'getInput')


### PR DESCRIPTION
The current sample breaks when you deploy it.  Without `jest.mock('@actions/core')` the `sets a failed status` unit test will actually fail the job.