### PR TITLE
Remove unused js-yaml dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "eslint-plugin-jsonc": "^2.10.0",
         "eslint-plugin-prettier": "^5.0.1",
         "jest": "^29.7.0",
-        "js-yaml": "^4.1.0",
         "make-coverage-badge": "^1.2.0",
         "prettier": "^3.1.0",
         "prettier-eslint": "^16.1.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "eslint-plugin-jsonc": "^2.10.0",
     "eslint-plugin-prettier": "^5.0.1",
     "jest": "^29.7.0",
-    "js-yaml": "^4.1.0",
     "make-coverage-badge": "^1.2.0",
     "prettier": "^3.1.0",
     "prettier-eslint": "^16.1.2",


### PR DESCRIPTION
As far as I can tell this isn't used, so it doesn't need to be in dev dependencies.