### PR TITLE
docs: fix rendering of warning in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,16 @@ So, what are you waiting for? Go ahead and start customizing your action!
    npm run all
    ```
 
-   > [!WARNING]
-   >
-   > This step is important! It will run [`ncc`](https://github.com/vercel/ncc)
-   > to build the final JavaScript action code with all dependencies included.
-   > If you do not run this step, your action will not work correctly when it is
-   > used in a workflow. This step also includes the `--license` option for
-   > `ncc`, which will create a license file for all of the production node
-   > modules used in your project.
+> [!WARNING]
+>
+> This step is important! It will run [`ncc`](https://github.com/vercel/ncc)
+> to build the final JavaScript action code with all dependencies included.
+> If you do not run this step, your action will not work correctly when it is
+> used in a workflow. This step also includes the `--license` option for
+> `ncc`, which will create a license file for all of the production node
+> modules used in your project.
 
-1. Commit your changes
+5. Commit your changes
 
    ```bash
    git add .

--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ So, what are you waiting for? Go ahead and start customizing your action!
 
 > [!WARNING]
 >
-> This step is important! It will run [`ncc`](https://github.com/vercel/ncc)
-> to build the final JavaScript action code with all dependencies included.
-> If you do not run this step, your action will not work correctly when it is
-> used in a workflow. This step also includes the `--license` option for
-> `ncc`, which will create a license file for all of the production node
-> modules used in your project.
+> This step is important! It will run [`ncc`](https://github.com/vercel/ncc) to
+> build the final JavaScript action code with all dependencies included. If you
+> do not run this step, your action will not work correctly when it is used in a
+> workflow. This step also includes the `--license` option for `ncc`, which will
+> create a license file for all of the production node modules used in your
+> project.
 
 5. Commit your changes
 

--- a/README.md
+++ b/README.md
@@ -124,16 +124,14 @@ So, what are you waiting for? Go ahead and start customizing your action!
    npm run all
    ```
 
-> [!WARNING]
->
-> This step is important! It will run [`ncc`](https://github.com/vercel/ncc) to
-> build the final JavaScript action code with all dependencies included. If you
-> do not run this step, your action will not work correctly when it is used in a
-> workflow. This step also includes the `--license` option for `ncc`, which will
-> create a license file for all of the production node modules used in your
-> project.
+   > This step is important! It will run [`ncc`](https://github.com/vercel/ncc)
+   > to build the final JavaScript action code with all dependencies included.
+   > If you do not run this step, your action will not work correctly when it is
+   > used in a workflow. This step also includes the `--license` option for
+   > `ncc`, which will create a license file for all of the production node
+   > modules used in your project.
 
-5. Commit your changes
+1. Commit your changes
 
    ```bash
    git add .


### PR DESCRIPTION
It looks like the GitHub alert syntax doesn't render correctly if nested into a list (probably something GitHub should fix/support). To fix in this repo, remove the indentation and then ensure the list continues from the correct number (it's technically two different lists now that there's a block between them).