### PR TITLE
Fix missing @jest/globals package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@actions/core": "^1.10.1"
       },
       "devDependencies": {
+        "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.30",
         "@typescript-eslint/eslint-plugin": "^7.3.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-jsonc": "^2.14.1",
     "eslint-plugin-prettier": "^5.1.3",
+    "@jest/globals": "^29.7.0",
     "jest": "^29.7.0",
     "make-coverage-badge": "^1.2.0",
     "prettier": "^3.2.5",


### PR DESCRIPTION
Hello!. Running `npm test` returns failure cuz one of the tests requires jest/globals.
 
<img width="855" alt="Screenshot 2024-03-27 at 22 21 47" src="https://github.com/actions/typescript-action/assets/3934971/aafe9ac6-9169-43cf-9c4f-a9ee9f57386a">
