### PR TITLE
Remove deprecated option

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -43,7 +43,6 @@ jobs:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TYPESCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSCPD: false


### PR DESCRIPTION
TYPESCRIPT_DEFAULT_STYLE has been deprecated
(https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md#upgrade-from-v670-to-v680)