### PR TITLE
Create .eslintrc.json in root directory.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": [".github/linters/.eslintrc.yml"]
+}


### PR DESCRIPTION
Hello! I noticed that the `.eslintrc.json` file has been deleted in [this commit](https://github.com/actions/typescript-action/pull/732/files#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090f). This will cause errors during development, such as the following:

![微信截图_20241025163611](https://github.com/user-attachments/assets/526b9b22-de1f-431f-bc82-542d919f3d23)

This file is essential for development. To avoid maintaining multiple rules files in the project, we can recreate it and extend the rules in `.github/linters/.eslintrc.yml`.