### PR TITLE
Fix error during initial release script run

### DIFF
--- a/script/release
+++ b/script/release
@@ -82,13 +82,20 @@ git tag "$new_tag" --annotate --message "$new_tag Release"
 echo -e "Tagged: ${BOLD_GREEN}$new_tag${OFF}"
 
 # 7. Set 'is_major_release' variable
-latest_major_release_tag=$(expr "$latest_tag" : "$major_semver_tag_regex")
 new_major_release_tag=$(expr "$new_tag" : "$major_semver_tag_regex")
 
-if ! [[ "$new_major_release_tag" = "$latest_major_release_tag" ]]; then
+if [[ "$latest_tag" = "[unknown]" ]]; then
+	# This is the first major release
 	is_major_release='yes'
 else
-	is_major_release='no'
+	# Compare the major version of the latest tag with the new tag
+	latest_major_release_tag=$(expr "$latest_tag" : "$major_semver_tag_regex")
+
+	if ! [[ "$new_major_release_tag" = "$latest_major_release_tag" ]]; then
+		is_major_release='yes'
+	else
+		is_major_release='no'
+	fi
 fi
 
 # 8. Point separate major release tag (e.g. v1, v2) to the new release
@@ -116,10 +123,10 @@ fi
 
 # 10. If this is a major release, create a 'releases/v#' branch and push
 if [ $is_major_release = 'yes' ]; then
-	git branch "releases/$latest_major_release_tag" "$latest_major_release_tag"
-	echo -e "Branch: ${BOLD_BLUE}releases/$latest_major_release_tag${OFF} created from ${BOLD_BLUE}$latest_major_release_tag${OFF} tag"
-	git push --set-upstream $git_remote "releases/$latest_major_release_tag"
-	echo -e "Branch: ${BOLD_GREEN}releases/$latest_major_release_tag${OFF} pushed to remote"
+	git branch "releases/$new_major_release_tag" "$new_major_release_tag"
+	echo -e "Branch: ${BOLD_BLUE}releases/$new_major_release_tag${OFF} created from ${BOLD_BLUE}$new_major_release_tag${OFF} tag"
+	git push --set-upstream $git_remote "releases/$new_major_release_tag"
+	echo -e "Branch: ${BOLD_GREEN}releases/$new_major_release_tag${OFF} pushed to remote"
 fi
 
 # Completed


### PR DESCRIPTION
Closes #937 

When the release script runs for the first time (no version tags exist in the repository yet), an error will occur that causes the script to exit early. This was caused by the script attempting to compare the latest tag with the new tag, but since there was no latest tag, the comparison failed.

This PR fixes this case by checking the latest tag before attempting to compare them.